### PR TITLE
Added .idea folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ target
 *.iml
 *.ipr
 *.iws
+.idea/


### PR DESCRIPTION
In `.gitignore`, there are already entries for ignoring IDEA-generated files. When setting up the project using the directory based project format, IDEA creates a folder named `.idea` 

This PR adds the `.idea`-folder to `.gitignore`
