### PR TITLE
Resolve #12 and #16

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -29,6 +29,9 @@ ${project.groupId}.annotation.*;version=${project.version}
 ,com.fasterxml.jackson.databind.introspect
 ,com.fasterxml.jackson.databind.type
 ,com.fasterxml.jackson.databind.util
+,javax.ws.rs
+,javax.ws.rs.core
+,javax.ws.rs.ext
 </osgi.import>
   </properties>
 


### PR DESCRIPTION
Resolve #12

Comma added to each line in _osgi.exports_ label of _pom.xml_ to get the correct MANIFEST.MF.

Old MANIFEST.MF only includes the first exported package:

```
...
Export-Package: com.fasterxml.jackson.jaxrs.annotation;version="2.2.3.
 SNAPSHOT"
...
```

And the new generated one includes all the exported packages:

```
...
Export-Package: com.fasterxml.jackson.jaxrs.annotation;version="2.2.3.
 SNAPSHOT",com.fasterxml.jackson.jaxrs.base;version="2.2.3.SNAPSHOT",c
 om.fasterxml.jackson.jaxrs.cfg;version="2.2.3.SNAPSHOT",com.fasterxml
 .jackson.jaxrs.util;version="2.2.3.SNAPSHOT"
...
```

Also resolve #16 adding _javax.ws.rs_, _javax.ws.rs.core_ and _javax.ws.rs.ext_ package to _osgi.imports_ label.
