### PR TITLE
Enables jackson to use the jax-rs 2.0 api within OSGi

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -31,9 +31,9 @@ ${project.groupId}.annotation.*;version=${project.version}
 ,com.fasterxml.jackson.databind.introspect
 ,com.fasterxml.jackson.databind.type
 ,com.fasterxml.jackson.databind.util
-,javax.ws.rs
-,javax.ws.rs.core
-,javax.ws.rs.ext
+,javax.ws.rs;version="${javax.ws.rs.version}"
+,javax.ws.rs.core;version="${javax.ws.rs.version}"
+,javax.ws.rs.ext;version="${javax.ws.rs.version}"
 </osgi.import>
   </properties>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -22,9 +22,9 @@
     <!-- NOTE: JAXB annotations module is optional dependency, need to try to mark
          as such here.
       -->
-    <osgi.import>javax.ws.rs
-,javax.ws.rs.core
-,javax.ws.rs.ext
+    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
+,javax.ws.rs.core;version="${javax.ws.rs.version}"
+,javax.ws.rs.ext;version="${javax.ws.rs.version}"
 ,com.fasterxml.jackson.annotation
 ,com.fasterxml.jackson.core
 ,com.fasterxml.jackson.core.type

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,10 @@
 
     <!--  Need Jersey+Jetty for testing -->
     <version.jersey>1.17.1</version.jersey>
-    <version.jetty>8.1.10.v20130312</version.jetty>      
+    <version.jetty>8.1.10.v20130312</version.jetty>
+    
+    <!-- Needed to enable jax-rs 2.0 usage under OSGi -->
+    <javax.ws.rs.version>[1.1.1,2.1)</javax.ws.rs.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hi,
this fixed https://github.com/FasterXML/jackson-jaxrs-providers/issues/37 for me.
Cheers
Lars
