### PR TITLE
Fix feature methods

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -312,8 +312,7 @@ public abstract class ProviderBase<
     // // // JaxRSFeature config
     
     public THIS configure(JaxRSFeature feature, boolean state) {
-        _jaxRSFeatures |= feature.getMask();
-        return _this();
+        return state ? enable(feature) : disable(feature);
     }
 
     public THIS enable(JaxRSFeature feature) {
@@ -353,12 +352,12 @@ public abstract class ProviderBase<
         return _this();
     }
     
-    public THIS enable(DeserializationFeature f, boolean state) {
+    public THIS enable(DeserializationFeature f) {
         _mapperConfig.configure(f, true);
         return _this();
     }
 
-    public THIS disable(DeserializationFeature f, boolean state) {
+    public THIS disable(DeserializationFeature f) {
         _mapperConfig.configure(f, false);
         return _this();
     }
@@ -370,34 +369,34 @@ public abstract class ProviderBase<
         return _this();
     }
 
-    public THIS enable(SerializationFeature f, boolean state) {
+    public THIS enable(SerializationFeature f) {
         _mapperConfig.configure(f, true);
         return _this();
     }
 
-    public THIS disable(SerializationFeature f, boolean state) {
+    public THIS disable(SerializationFeature f) {
         _mapperConfig.configure(f, false);
         return _this();
     }
     
     // // // JsonParser/JsonGenerator
     
-    public THIS enable(JsonParser.Feature f, boolean state) {
+    public THIS enable(JsonParser.Feature f) {
         _mapperConfig.configure(f, true);
         return _this();
     }
 
-    public THIS enable(JsonGenerator.Feature f, boolean state) {
+    public THIS enable(JsonGenerator.Feature f) {
         _mapperConfig.configure(f, true);
         return _this();
     }
 
-    public THIS disable(JsonParser.Feature f, boolean state) {
+    public THIS disable(JsonParser.Feature f) {
         _mapperConfig.configure(f, false);
         return _this();
     }
 
-    public THIS disable(JsonGenerator.Feature f, boolean state) {
+    public THIS disable(JsonGenerator.Feature f) {
         _mapperConfig.configure(f, false);
         return _this();
     }


### PR DESCRIPTION
@cowtowncoder I tried to use the configure method that accepts a `JaxRSFeature` but it didn't have any effect. After banging my head against a wall for a little bit I looked inside the method and saw that it was ignoring the `boolean state` parameter and just always enabled the feature. This PR updates the configure method to properly enable/disable based on the boolean parameter and also removes a bunch of extraneous boolean arguments that were also unused.