### PR TITLE
Provide alternate jars without META-INF/services.

### DIFF
--- a/cbor/pom.xml
+++ b/cbor/pom.xml
@@ -81,6 +81,27 @@
           </execution>
 	</executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>no-meta-inf-services</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>no-metainf-services</classifier>
+              <excludes>
+                <exclude>META-INF/services/**</exclude>
+              </excludes>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -85,6 +85,27 @@
           </execution>
 	</executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>no-meta-inf-services</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>no-metainf-services</classifier>
+              <excludes>
+                <exclude>META-INF/services/**</exclude>
+              </excludes>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -81,6 +81,27 @@
           </execution>
 	</executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>no-meta-inf-services</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>no-metainf-services</classifier>
+              <excludes>
+                <exclude>META-INF/services/**</exclude>
+              </excludes>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -101,6 +101,27 @@
           </execution>
 	</executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>no-meta-inf-services</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>no-metainf-services</classifier>
+              <excludes>
+                <exclude>META-INF/services/**</exclude>
+              </excludes>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Update the jackson-jaxrs-providers to provide additional jars for each
of the providers which do not include the META-INF/services files. This
will allow using the providers in situations where auto-registration is
not desired. Fixes issue #39.