### PR TITLE
add missing OSGi import to smile, yaml, and xml modules

### DIFF
--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -28,6 +28,7 @@
 ,com.fasterxml.jackson.core.type
 ,com.fasterxml.jackson.core.util
 ,com.fasterxml.jackson.databind
+,com.fasterxml.jackson.databind.cfg
 ,com.fasterxml.jackson.databind.introspect
 ,com.fasterxml.jackson.databind.type
 ,com.fasterxml.jackson.databind.util

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -28,6 +28,7 @@
 ,com.fasterxml.jackson.core.type
 ,com.fasterxml.jackson.core.util
 ,com.fasterxml.jackson.databind
+,com.fasterxml.jackson.databind.cfg
 ,com.fasterxml.jackson.databind.introspect
 ,com.fasterxml.jackson.databind.type
 ,com.fasterxml.jackson.databind.util

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -29,6 +29,7 @@ using standard Jackson data binding.
 ,com.fasterxml.jackson.core.type
 ,com.fasterxml.jackson.core.util
 ,com.fasterxml.jackson.databind
+,com.fasterxml.jackson.databind.cfg
 ,com.fasterxml.jackson.databind.introspect
 ,com.fasterxml.jackson.databind.type
 ,com.fasterxml.jackson.databind.util


### PR DESCRIPTION
#71 added the missing `com.fasterxml.jackson.databind.cfg` OSGi import to the `json` module but the `smile`, `yaml`, and `xml` modules also need this import.

Note that you should be able to use wildcards in your "osgi.import" instructions and the bundleplugin will expand them based on what's referenced in the compiled bytecode. Often people will leave a dangling `*` wildcard at the end as a catch-all in case they forget to update their imports when refactoring.