### PR TITLE
Fix issue#87 and add unit test

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -590,19 +590,14 @@ public abstract class ProviderBase<
                     //    generally not the intent. Fix may require addition of functionality in databind
 
 					TypeFactory typeFactory = writer.getTypeFactory();
-					rootType = typeFactory.constructType(genericType);
-					Class<?> rawClass = rootType.getRawClass();
+					JavaType baseType = typeFactory.constructType(genericType);
+					rootType = typeFactory.constructSpecializedType(baseType, type);
                     /* 26-Feb-2011, tatu: To help with [JACKSON-518], we better recognize cases where
                      *    type degenerates back into "Object.class" (as is the case with plain TypeVariable,
                      *    for example), and not use that.
                      */
-					if (rawClass == Object.class) {
+					if (rootType.getRawClass() == Object.class) {
 						rootType = null;
-					} else if (type != rawClass && !rootType.isCollectionLikeType() && !rootType.isMapLikeType()
-							&& rootType.hasGenericTypes()) {
-						List<JavaType> typeParameters = rootType.getBindings().getTypeParameters();
-						rootType = typeFactory.constructParametricType(type,
-								typeParameters.toArray(new JavaType[typeParameters.size()]));
 					}
                 }
             }


### PR DESCRIPTION
Notes :  
- the pom of module jackson-jaxrs-json-provider contains both jersey and resteasy dependency for test purpose. However at runtime because of the the way  JAX-RS services such as `RuntimeDelegate` are loaded (SPI) you can start a jersey server but use service of Resteasy instead of jersey ones (`org.jboss.resteasy.spi.ResteasyProviderFactory` instead of `org.glassfish.jersey.internal.RuntimeDelegateImpl` for example). 
So for the `com.fasterxml.jackson.jaxrs.json.jersey.SimpleEndpointTest.testDynamicTypingPages()` resteasy dependency must be removed of the pom to actually observe the issue and the fix.

- Second observation is that if you annotate `Page ` class with ` @JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="@class")` the test pass without the fix. Actually, I don't understand why when annotated with `@JsonTypeInfo ` links are serialized using `JsonLinkSerializer` and without annotation they are not.


