### PR TITLE
Implemented dynamic selection of NoContentException provider to back support of JaxRS 1.x

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/NoContentExceptionSupplier.java
@@ -1,0 +1,13 @@
+package com.fasterxml.jackson.jaxrs.base;
+
+import java.io.IOException;
+
+/**
+ * Implementors of this class contains strategies for NoContentException creation
+ */
+public interface NoContentExceptionSupplier
+{
+    String NO_CONTENT_MESSAGE = "No content (empty input stream)";
+
+    IOException createNoContentException();
+}

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
@@ -1,0 +1,18 @@
+package com.fasterxml.jackson.jaxrs.base.nocontent;
+
+import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
+
+import java.io.IOException;
+
+/**
+ * Create plain IOException for JaxRS 1.x because {@link javax.ws.rs.core.NoContentException}
+ * has been introduced in JaxRS 2.x
+ */
+public class JaxRS1NoContentExceptionSupplier implements NoContentExceptionSupplier
+{
+    @Override
+    public IOException createNoContentException()
+    {
+        return new IOException(NO_CONTENT_MESSAGE);
+    }
+}

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.jaxrs.base.nocontent;
+
+import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
+
+import javax.ws.rs.core.NoContentException;
+import java.io.IOException;
+
+/**
+ * This supplier creates fair NoContentException from JaxRS 2.x
+ */
+public class JaxRS2NoContentExceptionSupplier implements NoContentExceptionSupplier {
+    @Override
+    public IOException createNoContentException() {
+        return new NoContentException(NoContentExceptionSupplier.NO_CONTENT_MESSAGE);
+    }
+}


### PR DESCRIPTION
As discussed here https://github.com/FasterXML/jackson-jaxrs-providers/issues/90

Implemented approach with a dynamic selection of NoContentException creation strategy.
I did it in a bit another fashion than it was implemented previously to use reflection only once for a strategy selection, not for a creation of each instance.

Result:
```
CONFIG:     Provider found: class com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
```
During a container start.

Also, here https://github.com/Spikhalskiy/jackson-jaxrs-providers-compat-tests
is a separate module that depends on the old JaxRs and Jersey dependencies version. Test there fails on current master and works fine with this PR merged. Feel free to just pick it up as one more github.com/Jackson module.