### PR TITLE
Update OSGi build metadata to fix missing uses clause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,4 +116,21 @@
     </dependency>
 
   </dependencies>
+  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+            <instructions>
+              <_nouses>false</_nouses>
+            </instructions>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
This PR fixes #93 by doing two things:

* Update to the latest maven-bundle-plugin
* Remove the -nouses instruction which suppressed the necessary metadata

I'm not personally a fan of the maven-bundle plugin, but I understand the reluctance to move to a different build plugin in an otherwise stable project, so I've simply moved to a more up-to-date version which has better handling for annotation dependencies. 

The other thing that I've done is to re-enable the generation of uses clauses for package exports (i.e. to go back to the default configuration value). I'm not sure why this feature has been disabled throughout the Jackson project, as it means that all of the Jackson bundles are at risk of runtime failures (ranging from missing annotations to Linkage Errors). This feature really should not be disabled at a global level, so if there's a chance of fixing this higher up the stack then that would be a good idea.