### PR TITLE
Migrate to Jakarta EE 9

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -20,9 +20,9 @@ ${project.groupId}.annotation.*;version=${project.version}
 ,${project.groupId}.cfg.*;version=${project.version}
 ,${project.groupId}.util.*;version=${project.version}
 </osgi.export>
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}",
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}",
 *
 </osgi.import>
   </properties>

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/JsonMappingExceptionMapper.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/JsonMappingExceptionMapper.java
@@ -2,14 +2,14 @@ package com.fasterxml.jackson.jaxrs.base;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
 
 /**
  * Implementation if {@link ExceptionMapper} to send down a "400 Bad Request"
  * response in the event that unmappable JSON is received.
  *<p>
- * Note that {@link javax.ws.rs.ext.Provider} annotation was include up to
+ * Note that {@link jakarta.ws.rs.ext.Provider} annotation was include up to
  * Jackson 2.7, but removed from 2.8 (as per [jaxrs-providers#22]
  *
  * @since 2.2

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/JsonParseExceptionMapper.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/JsonParseExceptionMapper.java
@@ -2,14 +2,14 @@ package com.fasterxml.jackson.jaxrs.base;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
 
 /**
  * Implementation of {@link ExceptionMapper} to send down a "400 Bad Request"
  * in the event unparsable JSON is received.
  *<p>
- * Note that {@link javax.ws.rs.ext.Provider} annotation was include up to
+ * Note that {@link jakarta.ws.rs.ext.Provider} annotation was include up to
  * Jackson 2.7, but removed from 2.8 (as per [jaxrs-providers#22]
  *
  * @since 2.2

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -9,9 +9,9 @@ import java.security.PrivilegedAction;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.ws.rs.core.*;
-import javax.ws.rs.ext.MessageBodyReader;
-import javax.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;
@@ -38,7 +38,7 @@ public abstract class ProviderBase<
      */
     public final static String HEADER_CONTENT_TYPE_OPTIONS = "X-Content-Type-Options";
 
-    protected final static String CLASS_NAME_NO_CONTENT_EXCEPTION = "javax.ws.rs.core.NoContentException";
+    protected final static String CLASS_NAME_NO_CONTENT_EXCEPTION = "jakarta.ws.rs.core.NoContentException";
 
     protected final NoContentExceptionSupplier noContentExceptionSupplier = _createNoContentExceptionSupplier();
 
@@ -1012,7 +1012,7 @@ public abstract class ProviderBase<
     }
 
     /**
-     * Since class <code>javax.ws.rs.core.NoContentException</code> only exists in
+     * Since class <code>jakarta.ws.rs.core.NoContentException</code> only exists in
      * JAX-RS 2.0, but we want to have 1.x compatibility, need to dynamically select exception supplier
      */
     private static NoContentExceptionSupplier _createNoContentExceptionSupplier() {

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
 import java.io.IOException;
 
 /**
- * Create plain IOException for JaxRS 1.x because {@link javax.ws.rs.core.NoContentException}
+ * Create plain IOException for JaxRS 1.x because {@link jakarta.ws.rs.core.NoContentException}
  * has been introduced in JaxRS 2.x
  */
 public class JaxRS1NoContentExceptionSupplier implements NoContentExceptionSupplier

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.jaxrs.base.nocontent;
 
 import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
 
-import javax.ws.rs.core.NoContentException;
+import jakarta.ws.rs.core.NoContentException;
 import java.io.IOException;
 
 /**

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/JaxRSFeature.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/JaxRSFeature.java
@@ -22,7 +22,7 @@ public enum JaxRSFeature implements ConfigFeature
      * If set to true, empty content is allowed and will be read as Java 'null': if false,
      * an {@link java.io.IOException} will be thrown.
      *<p>
-     * NOTE: in case of JAX-RS 2.0, specific exception will be <code>javax.ws.rs.core.NoContentException</code>;
+     * NOTE: in case of JAX-RS 2.0, specific exception will be <code>jakarta.ws.rs.core.NoContentException</code>;
      * but this is not defined in JAX-RS 1.x.
      */
     ALLOW_EMPTY_INPUT(true),

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/ObjectReaderModifier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/ObjectReaderModifier.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.jaxrs.cfg;
 
 import java.io.IOException;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/ObjectWriterModifier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/ObjectWriterModifier.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.jaxrs.cfg;
 
 import java.io.IOException;
 
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import com.fasterxml.jackson.databind.*;
 

--- a/base/src/moditect/module-info.java
+++ b/base/src/moditect/module-info.java
@@ -5,7 +5,7 @@ module com.fasterxml.jackson.jaxrs.base {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     //Allow multiple implementations of ws.rs
-	requires static javax.ws.rs.api;
+	requires static jakarta.ws.rs.api;
 	requires static java.ws.rs;
 	requires static jakarta.ws.rs.api;
 

--- a/cbor/pom.xml
+++ b/cbor/pom.xml
@@ -20,9 +20,9 @@
     <!-- NOTE: JAXB annotations module is optional dependency, need to try to mark
          as such here.
       -->
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}"
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}"
 ,com.fasterxml.jackson.module.jaxb;resolution:=optional
 ,*
 </osgi.import>

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMediaTypes.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMediaTypes.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.jaxrs.cbor;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 public class CBORMediaTypes {
     // Should be the official one, from CBOR spec

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonCBORProvider.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.jaxrs.cbor;
 
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.ws.rs.ext.*;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.ext.*;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.jaxrs.cbor;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;

--- a/cbor/src/moditect/module-info.java
+++ b/cbor/src/moditect/module-info.java
@@ -6,12 +6,12 @@ module com.fasterxml.jackson.jaxrs.cbor {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.jaxrs.base;
-    requires javax.ws.rs.api;
+    requires jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.cbor;
 
-    provides javax.ws.rs.ext.MessageBodyReader with
+    provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jaxrs.cbor.JacksonCBORProvider;
-    provides javax.ws.rs.ext.MessageBodyWriter with
+    provides jakarta.ws.rs.ext.MessageBodyWriter with
         com.fasterxml.jackson.jaxrs.cbor.JacksonCBORProvider;
 }

--- a/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/TestCanDeserialize.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/TestCanDeserialize.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.cbor;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Unit test to check [JACKSON-540]

--- a/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/dw/ResourceTestBase.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/dw/ResourceTestBase.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -72,7 +72,7 @@ public abstract class ResourceTestBase extends JaxrsTestBase
         final ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);
         ServletHolder jaxrs = new ServletHolder(servletContainerClass());
-        jaxrs.setInitParameter("javax.ws.rs.Application", appClass.getName());
+        jaxrs.setInitParameter("jakarta.ws.rs.Application", appClass.getName());
         final ServletContextHandler mainHandler = new ServletContextHandler(contexts, "/", true, false);
         mainHandler.addServlet(jaxrs, "/*");
 

--- a/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/dw/SimpleEndpointTestBase.java
+++ b/cbor/src/test/java/com/fasterxml/jackson/jaxrs/cbor/dw/SimpleEndpointTestBase.java
@@ -3,9 +3,9 @@ package com.fasterxml.jackson.jaxrs.cbor.dw;
 import java.io.*;
 import java.net.*;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;

--- a/datatypes/src/main/java/com/fasterxml/jackson/datatype/jaxrs/Jaxrs2TypesModule.java
+++ b/datatypes/src/main/java/com/fasterxml/jackson/datatype/jaxrs/Jaxrs2TypesModule.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.datatype.jaxrs;
 
-import javax.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
  * Simple datatype module that adds serialization and deserialization
  * support for following JAX-RS 2.0 types:
  *<ul>
- * <li>{@link javax.ws.rs.core.Link}: serialized using "link header" representation
+ * <li>{@link jakarta.ws.rs.core.Link}: serialized using "link header" representation
  *  </li>
  * </ul>
  *

--- a/datatypes/src/main/java/com/fasterxml/jackson/datatype/jaxrs/LinkDeserializer.java
+++ b/datatypes/src/main/java/com/fasterxml/jackson/datatype/jaxrs/LinkDeserializer.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.datatype.jaxrs;
 
 import java.io.IOException;
 
-import javax.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/datatypes/src/moditect/module-info.java
+++ b/datatypes/src/moditect/module-info.java
@@ -2,7 +2,7 @@
 module com.fasterxml.jackson.datatype.jaxrs {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
-    requires javax.ws.rs.api;
+    requires jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.datatype.jaxrs;
 

--- a/datatypes/src/test/java/com/fasterxml/jackson/datatype/jaxrs/LinkTest.java
+++ b/datatypes/src/test/java/com/fasterxml/jackson/datatype/jaxrs/LinkTest.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.datatype.jaxrs;
 
-import javax.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,9 +20,9 @@
     <!-- NOTE: JAXB annotations module is optional dependency, need to try to mark
          as such here.
       -->
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}"
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}"
 ,com.fasterxml.jackson.module.jaxb;resolution:=optional
 ,*
 </osgi.import>

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.jaxrs.json;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProvider.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.jaxrs.json;
 
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.ws.rs.ext.*;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.ext.*;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;

--- a/json/src/moditect/module-info.java
+++ b/json/src/moditect/module-info.java
@@ -13,12 +13,12 @@ module com.fasterxml.jackson.jaxrs.json {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires static javax.ws.rs.api;
+    requires static jakarta.ws.rs.api;
     requires static java.ws.rs;
     requires static jakarta.ws.rs.api;
 
-    provides javax.ws.rs.ext.MessageBodyReader with
+    provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-    provides javax.ws.rs.ext.MessageBodyWriter with
+    provides jakarta.ws.rs.ext.MessageBodyWriter with
         com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 }

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestCanDeserialize.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestCanDeserialize.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Annotation;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.jaxrs.cfg.JaxRSFeature;
 
@@ -60,7 +60,7 @@ public class TestCanDeserialize extends JaxrsTestBase {
              verifyException(e, "no content");
              
              final String clsName = e.getClass().getName();
-             if ("javax.ws.rs.core.NoContentException".equals(clsName)) {
+             if ("jakarta.ws.rs.core.NoContentException".equals(clsName)) {
                  // Ideally, we'd get this
              } else if (e.getClass() == IOException.class) {
                  // but for JAX-RS 1.x this'll do

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJacksonFeatures.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJacksonFeatures.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.lang.annotation.*;
 import java.lang.reflect.Method;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJacksonFeatures.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJacksonFeatures.java
@@ -103,7 +103,7 @@ public class TestJacksonFeatures extends JaxrsTestBase
                     new ByteArrayInputStream("{ \"foobar\" : 3 }".getBytes("UTF-8")));
             fail("Should have caught an exception");
         } catch (JsonMappingException e) {
-            verifyException(e, "Unrecognized field");
+            verifyException(e, "Unrecognized property");
         }
     }
     

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJsonView.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJsonView.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JsonView;
 

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJsonpWrapping.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestJsonpWrapping.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.json;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 public class TestJsonpWrapping
     extends JaxrsTestBase

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestRootType.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestRootType.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestSerializeWithoutAutoflush.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestSerializeWithoutAutoflush.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DefaultTyping;

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestStreamingOutput.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestStreamingOutput.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.jaxrs.json;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.StreamingOutput;
 
 public class TestStreamingOutput extends JaxrsTestBase
 {

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestUntouchables.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/TestUntouchables.java
@@ -4,8 +4,8 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.StreamingOutput;
 
 /**
  * Unit tests for verifying that certain JDK base types will be

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/AnnotationTestBase.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/AnnotationTestBase.java
@@ -3,8 +3,8 @@ package com.fasterxml.jackson.jaxrs.json.dw;
 import java.io.*;
 import java.net.*;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.jetty.server.Server;
 

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/ResourceTestBase.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/ResourceTestBase.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -73,7 +73,7 @@ public abstract class ResourceTestBase extends JaxrsTestBase
         final ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);
         ServletHolder jaxrs = new ServletHolder(servletContainerClass());
-        jaxrs.setInitParameter("javax.ws.rs.Application", appClass.getName());
+        jaxrs.setInitParameter("jakarta.ws.rs.Application", appClass.getName());
         final ServletContextHandler mainHandler = new ServletContextHandler(contexts, "/", true, false);
         mainHandler.addServlet(jaxrs, "/*");
 

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/SimpleEndpointTestBase.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/SimpleEndpointTestBase.java
@@ -14,24 +14,24 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.GenericEntity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;
@@ -101,7 +101,7 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
     @JsonPropertyOrder({ "entities", "links" })
     @JsonAutoDetect(fieldVisibility = Visibility.ANY, creatorVisibility = Visibility.ANY, getterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
     protected static class PageImpl<E> extends Page<E> {
-        protected static class JsonLinkSerializer extends JsonSerializer<javax.ws.rs.core.Link> {
+        protected static class JsonLinkSerializer extends JsonSerializer<jakarta.ws.rs.core.Link> {
 
             static final String HREF_PROPERTY = "href";
 
@@ -117,7 +117,7 @@ public abstract class SimpleEndpointTestBase extends ResourceTestBase
             }
         }
 
-        protected static class JsonLinkDeserializer extends JsonDeserializer<javax.ws.rs.core.Link> {
+        protected static class JsonLinkDeserializer extends JsonDeserializer<jakarta.ws.rs.core.Link> {
 
 			@Override
 			public Link deserialize(JsonParser p, DeserializationContext deserializationContext)

--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/WriteModificationsTestBase.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/WriteModificationsTestBase.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.net.*;
 
 import javax.servlet.*;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.eclipse.jetty.server.Server;
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <!--  Need Jersey+Jetty for testing; deps from DropWizard 1.2.9 -->
     <version.jersey>3.0.0-M1</version.jersey>
     <!-- wrt CVE-2019-10247 -->
-    <version.jetty>9.4.17.v20190418</version.jetty>
+    <version.jetty>9.4.29.v20200521</version.jetty>
     
     <!-- Needed to enable jax-rs 3.0 usage under OSGi -->
     <jakarta.ws.rs.version>3.0.0</jakarta.ws.rs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> 
 
     <!--  Need Jersey+Jetty for testing; deps from DropWizard 1.2.9 -->
-    <version.jersey>2.25.1</version.jersey>
+    <version.jersey>3.0.0-M1</version.jersey>
     <!-- wrt CVE-2019-10247 -->
     <version.jetty>9.4.17.v20190418</version.jetty>
     
-    <!-- Needed to enable jax-rs 2.0 usage under OSGi -->
-    <javax.ws.rs.version>[2.0,2.2)</javax.ws.rs.version>
+    <!-- Needed to enable jax-rs 3.0 usage under OSGi -->
+    <jakarta.ws.rs.version>3.0.0</jakarta.ws.rs.version>
   </properties>
 
   <dependencyManagement>
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>2.3.2</version>
+        <version>3.0.0-RC3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -58,9 +58,9 @@
       by container (and app should definitely have direct dep too, when using annotations)
        -->
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1.1</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>3.0.0-M1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -101,6 +101,12 @@
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
+      <version>${version.jersey}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
       <version>${version.jersey}</version>
       <scope>test</scope>
     </dependency>

--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -20,9 +20,9 @@
     <!-- NOTE: JAXB annotations module is optional dependency, need to try to mark
          as such here.
       -->
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}"
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}"
 ,com.fasterxml.jackson.module.jaxb;resolution:=optional
 ,*
 </osgi.import>

--- a/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
+++ b/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.jaxrs.smile;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;

--- a/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/JacksonSmileProvider.java
@@ -2,9 +2,9 @@ package com.fasterxml.jackson.jaxrs.smile;
 
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.ws.rs.ext.*;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.ext.*;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;

--- a/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/SmileMediaTypes.java
+++ b/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/SmileMediaTypes.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.jaxrs.smile;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 public class SmileMediaTypes {
 	public static final String    APPLICATION_JACKSON_SMILE      = "application/x-jackson-smile";

--- a/smile/src/moditect/module-info.java
+++ b/smile/src/moditect/module-info.java
@@ -7,12 +7,12 @@ module com.fasterxml.jackson.jaxrs.smile {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.smile;
 
-    provides javax.ws.rs.ext.MessageBodyReader with
+    provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jaxrs.smile.JacksonSmileProvider;
-    provides javax.ws.rs.ext.MessageBodyWriter with
+    provides jakarta.ws.rs.ext.MessageBodyWriter with
         com.fasterxml.jackson.jaxrs.smile.JacksonSmileProvider;
 }

--- a/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/TestCanDeserialize.java
+++ b/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/TestCanDeserialize.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.smile;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Unit test to check [JACKSON-540]

--- a/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/dw/ResourceTestBase.java
+++ b/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/dw/ResourceTestBase.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -72,7 +72,7 @@ public abstract class ResourceTestBase extends JaxrsTestBase
         final ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);
         ServletHolder jaxrs = new ServletHolder(servletContainerClass());
-        jaxrs.setInitParameter("javax.ws.rs.Application", appClass.getName());
+        jaxrs.setInitParameter("jakarta.ws.rs.Application", appClass.getName());
         final ServletContextHandler mainHandler = new ServletContextHandler(contexts, "/", true, false);
         mainHandler.addServlet(jaxrs, "/*");
 

--- a/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/dw/SimpleEndpointTestBase.java
+++ b/smile/src/test/java/com/fasterxml/jackson/jaxrs/smile/dw/SimpleEndpointTestBase.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.smile.dw;
 import java.io.*;
 import java.net.*;
 
-import javax.ws.rs.*;
+import jakarta.ws.rs.*;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -20,9 +20,9 @@
     <!-- NOTE: JAXB annotations module is NOT optional for xml format:
 ,com.fasterxml.jackson.module.jaxb;resolution:=optional
       -->
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}"
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}"
 ,*
 </osgi.import>
   </properties>

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
@@ -1,9 +1,9 @@
 package com.fasterxml.jackson.jaxrs.xml;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonXMLProvider.java
@@ -3,10 +3,10 @@ package com.fasterxml.jackson.jaxrs.xml;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.*;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.*;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.databind.*;

--- a/xml/src/moditect/module-info.java
+++ b/xml/src/moditect/module-info.java
@@ -7,13 +7,13 @@ module com.fasterxml.jackson.jaxrs.yaml {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.xml;
 
-    provides javax.ws.rs.ext.MessageBodyReader with
+    provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
-    provides javax.ws.rs.ext.MessageBodyWriter with
+    provides jakarta.ws.rs.ext.MessageBodyWriter with
         com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 
 }

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestCanDeserialize.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestCanDeserialize.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.xml;
 import java.io.*;
 import java.lang.annotation.Annotation;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 public class TestCanDeserialize extends JaxrsTestBase
 {

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJacksonFeaturesWithXML.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJacksonFeaturesWithXML.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.lang.annotation.*;
 import java.lang.reflect.Method;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
 

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJacksonFeaturesWithXML.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJacksonFeaturesWithXML.java
@@ -115,7 +115,7 @@ public class TestJacksonFeaturesWithXML extends JaxrsTestBase
                     new ByteArrayInputStream("<Bean><foobar>3</foobar></Bean>".getBytes("UTF-8")));
             fail("Should have caught an exception");
         } catch (JsonMappingException e) {
-            verifyException(e, "Unrecognized field");
+            verifyException(e, "Unrecognized property");
         }
     }
     

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJsonView.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestJsonView.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestRootType.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestRootType.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestSerialize.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestSerialize.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.util.*;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestUntouchables.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/TestUntouchables.java
@@ -2,8 +2,8 @@ package com.fasterxml.jackson.jaxrs.xml;
 
 import java.util.*;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.StreamingOutput;
 
 import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/dw/ResourceTestBase.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/dw/ResourceTestBase.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -72,7 +72,7 @@ public abstract class ResourceTestBase extends JaxrsTestBase
         final ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);
         ServletHolder jaxrs = new ServletHolder(servletContainerClass());
-        jaxrs.setInitParameter("javax.ws.rs.Application", appClass.getName());
+        jaxrs.setInitParameter("jakarta.ws.rs.Application", appClass.getName());
         final ServletContextHandler mainHandler = new ServletContextHandler(contexts, "/", true, false);
         mainHandler.addServlet(jaxrs, "/*");
 

--- a/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/dw/SimpleEndpointTestBase.java
+++ b/xml/src/test/java/com/fasterxml/jackson/jaxrs/xml/dw/SimpleEndpointTestBase.java
@@ -3,10 +3,10 @@ package com.fasterxml.jackson.jaxrs.xml.dw;
 import java.io.*;
 import java.net.*;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -21,9 +21,9 @@ using standard Jackson data binding.
     <!-- NOTE: JAXB annotations module is optional dependency, need to try to mark
          as such here.
       -->
-    <osgi.import>javax.ws.rs;version="${javax.ws.rs.version}"
-,javax.ws.rs.core;version="${javax.ws.rs.version}"
-,javax.ws.rs.ext;version="${javax.ws.rs.version}"
+    <osgi.import>jakarta.ws.rs;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.core;version="${jakarta.ws.rs.version}"
+,jakarta.ws.rs.ext;version="${jakarta.ws.rs.version}"
 ,com.fasterxml.jackson.module.jaxb;resolution:=optional
 ,*
 </osgi.import>

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
@@ -3,10 +3,10 @@ package com.fasterxml.jackson.jaxrs.yaml;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.Provider;
 
 /**
  * JSON content type provider automatically configured to use both Jackson

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
@@ -9,11 +9,11 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.jaxrs.base.ProviderBase;
 import com.fasterxml.jackson.jaxrs.cfg.Annotations;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.*;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/YAMLMediaTypes.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/YAMLMediaTypes.java
@@ -1,6 +1,6 @@
 package com.fasterxml.jackson.jaxrs.yaml;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 // as per [jaxrs-providers#75]
 public class YAMLMediaTypes {

--- a/yaml/src/moditect/module-info.java
+++ b/yaml/src/moditect/module-info.java
@@ -7,13 +7,13 @@ module com.fasterxml.jackson.jaxrs.yaml {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.yaml;
 
-    provides javax.ws.rs.ext.MessageBodyReader with
+    provides jakarta.ws.rs.ext.MessageBodyReader with
         com.fasterxml.jackson.jaxrs.yaml.JacksonYAMLProvider;
-    provides javax.ws.rs.ext.MessageBodyWriter with
+    provides jakarta.ws.rs.ext.MessageBodyWriter with
         com.fasterxml.jackson.jaxrs.yaml.JacksonYAMLProvider;
 
 }

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/JaxrsTestBase.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/JaxrsTestBase.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.core.JsonToken;
 
 import org.junit.Assert;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJacksonFeaturesWithYAML.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJacksonFeaturesWithYAML.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.jaxrs.annotation.JacksonFeatures;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.lang.annotation.*;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJacksonFeaturesWithYAML.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJacksonFeaturesWithYAML.java
@@ -106,7 +106,7 @@ public class TestJacksonFeaturesWithYAML extends JaxrsTestBase
                     new ByteArrayInputStream("---\nBean:\n  foobar: 3\n".getBytes("UTF-8")));
             fail("Should have caught an exception");
         } catch (JsonMappingException e) {
-            verifyException(e, "Unrecognized field");
+            verifyException(e, "Unrecognized property");
         }
     }
     

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJsonView.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestJsonView.java
@@ -2,7 +2,7 @@ package com.fasterxml.jackson.jaxrs.yaml;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestRootType.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestRootType.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestSerialize.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestSerialize.java
@@ -3,7 +3,7 @@ package com.fasterxml.jackson.jaxrs.yaml;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestUntouchables.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/TestUntouchables.java
@@ -1,7 +1,7 @@
 package com.fasterxml.jackson.jaxrs.yaml;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.StreamingOutput;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/dw/ResourceTestBase.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/dw/ResourceTestBase.java
@@ -10,7 +10,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -72,7 +72,7 @@ public abstract class ResourceTestBase extends JaxrsTestBase
         final ContextHandlerCollection contexts = new ContextHandlerCollection();
         server.setHandler(contexts);
         ServletHolder jaxrs = new ServletHolder(servletContainerClass());
-        jaxrs.setInitParameter("javax.ws.rs.Application", appClass.getName());
+        jaxrs.setInitParameter("jakarta.ws.rs.Application", appClass.getName());
         final ServletContextHandler mainHandler = new ServletContextHandler(contexts, "/", true, false);
         mainHandler.addServlet(jaxrs, "/*");
 

--- a/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/dw/SimpleEndpointTestBase.java
+++ b/yaml/src/test/java/com/fasterxml/jackson/jaxrs/yaml/dw/SimpleEndpointTestBase.java
@@ -12,10 +12,10 @@ import com.fasterxml.jackson.jaxrs.yaml.YAMLMediaTypes;
 import org.eclipse.jetty.server.Server;
 import org.junit.Assert;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Jakarta EE 9 platform renames all the "old" namespaces from javax.* to jakarta.*. This pull request performs this migration so that when Jacakrta EE 9 is released in [June 2020](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9ReleasePlan#proposed-progress-reviews) it will be compatible.

I ran mvn test and [travis builds](https://travis-ci.com/github/tamersaadeh/jackson-jaxrs-providers) with no failures*.

Note 1: this is completely incompatible with the old namespace, so probably the major version of the library should be bumped.
Note 2: currently depends on pre-released versions of the JAXB specification (RC3). This can be updated when the final version is released.
Note 3: this PR is similar to my PR for FasterXML/jackson-modules-base#95 and FasterXML/jackson-dataformat-xml#407

*: I needed to modify 3 tests (7ff95e7a6195f85b83ebae46cc41970a52a7d89f) but I'm not exactly sure way this change was needed on my development PC.