### PR TITLE
Adding ppc64le architecture support on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,18 @@ jdk:
   - openjdk8
   - openjdk11
 
+arch:
+  - ppc64le
+  - amd64
+   
 # whitelist
 branches:
   only:
     - master
     - "3.0"
+
+before_install: 
+  - mkdir -p /opt/maven
+  - curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz|tar -xz --strip 1 -C /opt/maven
+  - export MAVEN_HOME=/opt/maven
+  - export PATH=${MAVEN_HOME}/bin:${PATH}


### PR DESCRIPTION
Hi, 
I had added ppc64le support on travis-ci  and looks like its been successfully added. I believe it is ready for the final review and merge. 

The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/jackson-jaxrs-providers/builds/181239941
Please have a look.

Thanks!!"