### PR TITLE
Allow multiple implementations of JAX-RS for all providers

### DIFF
--- a/cbor/src/moditect/module-info.java
+++ b/cbor/src/moditect/module-info.java
@@ -6,7 +6,10 @@ module com.fasterxml.jackson.jaxrs.cbor {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.jaxrs.base;
-    requires javax.ws.rs.api;
+
+    requires static javax.ws.rs.api;
+    requires static java.ws.rs;
+    requires static jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.cbor;
 

--- a/datatypes/src/moditect/module-info.java
+++ b/datatypes/src/moditect/module-info.java
@@ -2,7 +2,10 @@
 module com.fasterxml.jackson.datatype.jaxrs {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
-    requires javax.ws.rs.api;
+
+    requires static javax.ws.rs.api;
+    requires static java.ws.rs;
+    requires static jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.datatype.jaxrs;
 

--- a/smile/src/moditect/module-info.java
+++ b/smile/src/moditect/module-info.java
@@ -7,7 +7,9 @@ module com.fasterxml.jackson.jaxrs.smile {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires static javax.ws.rs.api;
+    requires static java.ws.rs;
+    requires static jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.smile;
 

--- a/xml/src/moditect/module-info.java
+++ b/xml/src/moditect/module-info.java
@@ -1,5 +1,5 @@
 // Generated 02-Apr-2019 using Moditect maven plugin
-module com.fasterxml.jackson.jaxrs.yaml {
+module com.fasterxml.jackson.jaxrs.xml {
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.dataformat.xml;
@@ -7,7 +7,9 @@ module com.fasterxml.jackson.jaxrs.yaml {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires static javax.ws.rs.api;
+    requires static java.ws.rs;
+    requires static jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.xml;
 

--- a/yaml/src/moditect/module-info.java
+++ b/yaml/src/moditect/module-info.java
@@ -7,7 +7,9 @@ module com.fasterxml.jackson.jaxrs.yaml {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
-    requires javax.ws.rs.api;
+    requires static javax.ws.rs.api;
+    requires static java.ws.rs;
+    requires static jakarta.ws.rs.api;
 
     exports com.fasterxml.jackson.jaxrs.yaml;
 


### PR DESCRIPTION
Hi,

please consider merging this PR which extends #121 to all providers, so that they could be leveraged in modularized applications using newer version of JAX-RS while remaining backward compatible. 

I've encountered the problem with `jackson-jaxrs-xml-provider` but it makes sense to fix them all in one go just like `jackson-jaxrs-json-provider` was. It should also be fine to port it to `2.11` and `2.12` branches if you like. Please also note that I've changed the name of `jackson-jaxrs-xml-provider` module from `com.fasterxml.jackson.jaxrs.yaml` to `com.fasterxml.jackson.jaxrs.xml`. All other seem to be consistent.

Finally, please note that #124 seems to be breaking the `module-info.java` of all subprojects. After merging this PR, #124 should be adjusted so that it doesn't change any `module-info.java` file. 

Let me know what you think! :smile: 