### PR TITLE
Module-Info Enhancements - JAX-RS updates for Jakarta Release version

### DIFF
--- a/json/src/moditect/module-info.java
+++ b/json/src/moditect/module-info.java
@@ -12,8 +12,15 @@ module com.fasterxml.jackson.jaxrs.json {
 
     requires com.fasterxml.jackson.jaxrs.base;
 
+    //oracle location
     requires static javax.ws.rs.api;
+    //oracle location
     requires static java.ws.rs;
+    //jakarta initial location - 2.x
+    requires static javax.ws.rs;
+    //jakarta 3.x final location - https://github.com/jboss/jboss-jakarta-jaxrs-api_spec
+    requires static jakarta.ws.rs;
+    //jakarta 3.x final location - https://github.com/eclipse-ee4j/jaxrs-api
     requires static jakarta.ws.rs.api;
 
     provides javax.ws.rs.ext.MessageBodyReader with


### PR DESCRIPTION
Zero impact on backwards compatibility
https://github.com/FasterXML/jackson-databind/issues/2910

Adds support for the following maven coordinates in JMS : 

```
<dependency>
    <groupId>jakarta.ws.rs</groupId>
    <artifactId>jakarta.ws.rs-api</artifactId>
    <version>3.0.0-M1</version>
</dependency>

<dependency>
    <groupId>jakarta.ws.rs</groupId>
    <artifactId>jakarta.ws.rs-api</artifactId>
    <version>2.1.6</version>
</dependency>

<dependency>
    <groupId>javax.ws.rs</groupId>
    <artifactId>javax.ws.rs-api</artifactId>
    <version>2.1.1</version>
</dependency>

```

