### PR TITLE
Create manifest files separately and reference in bundle plugin, THEN shade in the new manifest for Jakarta separately before install

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -74,6 +74,14 @@ ${project.groupId}.annotation.*;version=${project.version}
                   <include>${project.groupId}:${project.artifactId}</include>
                 </includes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>javax.xml.bind</pattern>
@@ -94,10 +102,9 @@ ${project.groupId}.annotation.*;version=${project.version}
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
-                  <delegates>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
-                  </delegates>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${build.directory}/jakarta/MANIFEST.MF</file>
                 </transformer>
               </transformers>
             </configuration>
@@ -110,6 +117,45 @@ ${project.groupId}.annotation.*;version=${project.version}
             <version>0.0.1</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+  <!-- Jakarta bundle fix - nb place last for execution order on package phase
+  @gedmarc 20210222-->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.1</version>
+        <executions>
+          <execution>
+            <id>default_bundle</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/javax</manifestLocation>
+              <packaging>jar</packaging>
+              <instructions>
+                <_nouses>false</_nouses>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle_jakarta_manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/jakarta</manifestLocation>
+              <classifier>jakarta</classifier>
+              <packaging>jar</packaging>
+              <instructions>
+                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -83,10 +83,33 @@ ${project.groupId}.annotation.*;version=${project.version}
                   <pattern>javax.ws.rs</pattern>
                   <shadedPattern>jakarta.ws.rs</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>jakarta.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.validation</pattern>
+                  <shadedPattern>jakarta.validation</shadedPattern>
+                </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
+                  <delegates>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                  </delegates>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.yupiik.maven</groupId>
+            <artifactId>maven-shade-transformers</artifactId>
+            <version>0.0.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
     </plugins>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -99,6 +99,14 @@
                   <include>${project.groupId}:${project.artifactId}</include>
                 </includes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>javax.xml.bind</pattern>
@@ -119,10 +127,9 @@
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
-                  <delegates>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
-                  </delegates>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${build.directory}/jakarta/MANIFEST.MF</file>
                 </transformer>
               </transformers>
             </configuration>
@@ -135,6 +142,45 @@
             <version>0.0.1</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+      <!-- Jakarta bundle fix - nb place last for execution order on package phase
+      @gedmarc 20210222-->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.1</version>
+        <executions>
+          <execution>
+            <id>default_bundle</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/javax</manifestLocation>
+              <packaging>jar</packaging>
+              <instructions>
+                <_nouses>false</_nouses>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle_jakarta_manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/jakarta</manifestLocation>
+              <classifier>jakarta</classifier>
+              <packaging>jar</packaging>
+              <instructions>
+                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -108,10 +108,33 @@
                   <pattern>javax.ws.rs</pattern>
                   <shadedPattern>jakarta.ws.rs</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>jakarta.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.validation</pattern>
+                  <shadedPattern>jakarta.validation</shadedPattern>
+                </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
+                  <delegates>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                  </delegates>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.yupiik.maven</groupId>
+            <artifactId>maven-shade-transformers</artifactId>
+            <version>0.0.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
     </plugins>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -134,6 +134,14 @@
                   <include>${project.groupId}:${project.artifactId}</include>
                 </includes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>javax.xml.bind</pattern>
@@ -154,10 +162,9 @@
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
-                  <delegates>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
-                  </delegates>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${build.directory}/jakarta/MANIFEST.MF</file>
                 </transformer>
               </transformers>
             </configuration>
@@ -170,6 +177,45 @@
             <version>0.0.1</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+      <!-- Jakarta bundle fix - nb place last for execution order on package phase
+      @gedmarc 20210222-->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.1</version>
+        <executions>
+          <execution>
+            <id>default_bundle</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/javax</manifestLocation>
+              <packaging>jar</packaging>
+              <instructions>
+                <_nouses>false</_nouses>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle_jakarta_manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/jakarta</manifestLocation>
+              <classifier>jakarta</classifier>
+              <packaging>jar</packaging>
+              <instructions>
+                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -143,10 +143,33 @@
                   <pattern>javax.ws.rs</pattern>
                   <shadedPattern>jakarta.ws.rs</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>jakarta.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.validation</pattern>
+                  <shadedPattern>jakarta.validation</shadedPattern>
+                </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
+                  <delegates>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                  </delegates>
+                </transformer>
+              </transformers>
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.yupiik.maven</groupId>
+            <artifactId>maven-shade-transformers</artifactId>
+            <version>0.0.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,14 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>5.1.1</version>
           <configuration>
             <instructions>
               <_nouses>false</_nouses>
             </instructions>
           </configuration>
         </plugin>
+
         <plugin>
           <!-- Inherited from oss-base. Generate PackageVersion.java.-->
           <groupId>com.google.code.maven-replacer-plugin</groupId>
@@ -155,10 +156,11 @@
 
     <!-- 05-Jul-2020, tatu: Add generation of Gradle Module Metadata -->
     <plugins>
-      <plugin>
+
+     <plugin>
         <groupId>de.jjohannes</groupId>
         <artifactId>gradle-module-metadata-maven-plugin</artifactId>
-      </plugin>    
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -113,6 +113,63 @@
         <groupId>org.moditect</groupId>
         <artifactId>moditect-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jakarta</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>jakarta</shadedClassifierName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>${project.groupId}:${project.artifactId}</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>javax.xml.bind</pattern>
+                  <shadedPattern>jakarta.xml.bind</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.ws.rs</pattern>
+                  <shadedPattern>jakarta.ws.rs</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>jakarta.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.validation</pattern>
+                  <shadedPattern>jakarta.validation</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
+                  <delegates>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                  </delegates>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.yupiik.maven</groupId>
+            <artifactId>maven-shade-transformers</artifactId>
+            <version>0.0.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -133,6 +133,14 @@
                   <include>${project.groupId}:${project.artifactId}</include>
                 </includes>
               </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>${project.groupId}:${project.artifactId}</artifact>
+                  <excludes>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>javax.xml.bind</pattern>
@@ -153,10 +161,9 @@
               </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                <transformer implementation="io.yupiik.maven.shade.transformer.RelocationTransformer">
-                  <delegates>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
-                  </delegates>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${build.directory}/jakarta/MANIFEST.MF</file>
                 </transformer>
               </transformers>
             </configuration>
@@ -169,6 +176,45 @@
             <version>0.0.1</version>
           </dependency>
         </dependencies>
+      </plugin>
+
+      <!-- Jakarta bundle fix - nb place last for execution order on package phase
+      @gedmarc 20210222-->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.1</version>
+        <executions>
+          <execution>
+            <id>default_bundle</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/javax</manifestLocation>
+              <packaging>jar</packaging>
+              <instructions>
+                <_nouses>false</_nouses>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>bundle_jakarta_manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${build.directory}/jakarta</manifestLocation>
+              <classifier>jakarta</classifier>
+              <packaging>jar</packaging>
+              <instructions>
+                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Runs the bundle plugin twice, once for the creation of the original bundle, and again for the changes to the jakarta packing.
The manifest files are placed in target/jakarta and are picked up by the shading and replaces the javax manifest

https://github.com/FasterXML/jackson-jaxrs-providers/issues/132