### PR TITLE
Remove Jakarta bundle fix added in #136 to try to fix #138

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-base</artifactId>
   <name>Jackson-JAXRS-base</name>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -116,44 +116,6 @@ ${project.groupId}.annotation.*;version=${project.version}
         </dependencies>
       </plugin>
 
-  <!-- Jakarta bundle fix - nb place last for execution order on package phase
-  @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-base</artifactId>
   <name>Jackson-JAXRS-base</name>

--- a/cbor/pom.xml
+++ b/cbor/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-cbor-provider</artifactId>
   <name>Jackson-JAXRS-CBOR</name>

--- a/cbor/pom.xml
+++ b/cbor/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-cbor-provider</artifactId>
   <name>Jackson-JAXRS-CBOR</name>

--- a/cbor/pom.xml
+++ b/cbor/pom.xml
@@ -157,43 +157,6 @@
         </dependencies>
       </plugin>
 
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <!-- note: different group id, it being datatype -->
   <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <!-- note: different group id, it being datatype -->
   <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/datatypes/pom.xml
+++ b/datatypes/pom.xml
@@ -141,44 +141,6 @@
         </dependencies>
       </plugin>
 
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 </project>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-json-provider</artifactId>
   <name>Jackson-JAXRS-JSON</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-json-provider</artifactId>
   <name>Jackson-JAXRS-JSON</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -179,43 +179,6 @@
         </dependencies>
       </plugin>
 
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.fasterxml.jackson.jaxrs</groupId>
   <artifactId>jackson-jaxrs-providers</artifactId>
   <name>Jackson JAX-RS</name>
-  <version>2.12.2-SNAPSHOT</version>
+  <version>2.12.2</version>
   <packaging>pom</packaging>
   <description>Parent for Jackson JAX-RS providers
   </description>
@@ -28,7 +28,7 @@
     <connection>scm:git:git@github.com:FasterXML/jackson-jaxrs-providers.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-jaxrs-providers.git</developerConnection>
     <url>http://github.com/FasterXML/jackson-jaxrs-providers</url>    
-    <tag>jackson-jaxrs-providers-2.12.2</tag>
+    <tag>2.12.2-e</tag>
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.fasterxml.jackson.jaxrs</groupId>
   <artifactId>jackson-jaxrs-providers</artifactId>
   <name>Jackson JAX-RS</name>
-  <version>2.12.2</version>
+  <version>2.12.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Parent for Jackson JAX-RS providers
   </description>
@@ -28,7 +28,7 @@
     <connection>scm:git:git@github.com:FasterXML/jackson-jaxrs-providers.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-jaxrs-providers.git</developerConnection>
     <url>http://github.com/FasterXML/jackson-jaxrs-providers</url>    
-    <tag>2.12.2-e</tag>
+    <tag>jackson-jaxrs-providers-2.12.2</tag>
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> 

--- a/pom.xml
+++ b/pom.xml
@@ -171,9 +171,8 @@
         <artifactId>gradle-module-metadata-maven-plugin</artifactId>
       </plugin>
 
-      <!-- 05-Mar-2021, tatu: temporary override to prevent auto-close on release
+      <!-- 05-Mar-2021, tatu: needed temporary override to prevent auto-close on release
 https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment
-        -->
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -181,6 +180,7 @@ https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project
           <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
         </configuration>
       </plugin>
+        -->
       
     </plugins>
   </build>

--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -156,44 +156,6 @@
           </dependency>
         </dependencies>
       </plugin>
-
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-smile-provider</artifactId>
   <name>Jackson-JAXRS-Smile</name>

--- a/smile/pom.xml
+++ b/smile/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-smile-provider</artifactId>
   <name>Jackson-JAXRS-Smile</name>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-xml-provider</artifactId>
   <name>Jackson-JAXRS-XML</name>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-xml-provider</artifactId>
   <name>Jackson-JAXRS-XML</name>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -178,43 +178,6 @@
         </dependencies>
       </plugin>
 
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -172,43 +172,6 @@ using standard Jackson data binding.
         </dependencies>
       </plugin>
 
-      <!-- Jakarta bundle fix - nb place last for execution order on package phase
-      @gedmarc 20210222-->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default_bundle</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/javax</manifestLocation>
-              <packaging>jar</packaging>
-              <instructions>
-                <_nouses>false</_nouses>
-              </instructions>
-            </configuration>
-          </execution>
-          <execution>
-            <id>bundle_jakarta_manifest</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${build.directory}/jakarta</manifestLocation>
-              <classifier>jakarta</classifier>
-              <packaging>jar</packaging>
-              <instructions>
-                <Import-Package>jakarta.ws.rs;version="[3.0,4)",jakarta.ws.rs.core;version="[3.0,4)",jakarta.ws.rs.ext;version="[3.0,4)",!javax.ws*,*</Import-Package>
-              </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2</version>
+    <version>2.12.3-SNAPSHOT</version>
   </parent>
   <artifactId>jackson-jaxrs-yaml-provider</artifactId>
   <name>Jackson-JAXRS-YAML</name>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.fasterxml.jackson.jaxrs</groupId>
     <artifactId>jackson-jaxrs-providers</artifactId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.12.2</version>
   </parent>
   <artifactId>jackson-jaxrs-yaml-provider</artifactId>
   <name>Jackson-JAXRS-YAML</name>


### PR DESCRIPTION
As per title: 2.12.2 release of JAX-RS components failed due to odd (and not yet understood) problem where in .pom files are missing, presumably due to post-processing done to fix references for OSGi manifest for of "jakarta" flavor implementations.
