### PR TITLE
Fix Flaky: com.fasterxml.jackson.jaxrs.base.cfg.AnnotationBundleKeyTest

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/AnnotationBundleKey.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/AnnotationBundleKey.java
@@ -28,6 +28,11 @@ public final class AnnotationBundleKey
     
     private final boolean _annotationsCopied;
 
+    /**
+     * This variable is previously used for check equality.
+     * It is not used anymore in this file but there are some external links.
+     * Consider remove this variable.
+     */
     private final int _hashCode;
     
     /*

--- a/base/src/test/java/com/fasterxml/jackson/jaxrs/base/cfg/AnnotationBundleKeyTest.java
+++ b/base/src/test/java/com/fasterxml/jackson/jaxrs/base/cfg/AnnotationBundleKeyTest.java
@@ -10,8 +10,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.jaxrs.base.BaseTestBase;
 import com.fasterxml.jackson.jaxrs.cfg.AnnotationBundleKey;
 
-import static org.junit.Assert.assertNotEquals;
-
 // for [jaxrs-providers#111]
 public class AnnotationBundleKeyTest
     extends BaseTestBase


### PR DESCRIPTION
The previous test suite `AnnotationBundleKeyTest` is flaky when checking two annotations is equal. 
The root cause is that `getAnnotations()` is not consistent in order despite the package states it is. 
Luckily tatu already commented that the order-dependent `AnnotationBundleKey.equal()` brings some false-negatives results. In this fix I made the `equal()` function order-insensitive to remove the flakiness.

Notes:
In `AnnotationBundleKey` the `hashcode` is no longer used for real work. Maybe someone can go check whether it's same to remove the variable.