### PR TITLE
fix a flaky test

### DIFF
--- a/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/WriteModificationsTestBase.java
+++ b/json/src/test/java/com/fasterxml/jackson/jaxrs/json/dw/WriteModificationsTestBase.java
@@ -163,11 +163,15 @@ public abstract class WriteModificationsTestBase extends ResourceTestBase
         try {
             // First, without indent:
             String json = readUTF8(new URL(URL_BASE).openStream());
-            assertEquals(aposToQuotes("{'x':1,'y':2}"), json);
-    
+            boolean quote1 = json.equals(aposToQuotes("{'x':1,'y':2}"));
+            boolean quote2 = json.equals(aposToQuotes("{'y':2,'x':1}"));
+            assertTrue(quote1 || quote2);
+            
             // and then with indentation
             json = readUTF8(new URL(URL_BASE + "?indent=true").openStream());
-            assertEquals(aposToQuotes("{\n  'x' : 1,\n  'y' : 2\n}"), json);
+            boolean quote3 = json.equals(aposToQuotes("{\n  'x' : 1,\n  'y' : 2\n}"));
+            boolean quote4 = json.equals(aposToQuotes("{\n  'y' : 2,\n  'x' : 1\n}"));
+            assertTrue(quote3 || quote4);
         } finally {
             server.stop();
         }


### PR DESCRIPTION
`aposToQuotes` returns a string with the nondeterministic order of the map. Therefore, there are more possibilities of the combination of x and y. 