### PR TITLE
Remove unnecessary synchronization from endpoint reader/writer caches

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -675,7 +675,6 @@ public abstract class ProviderBase<
             return _configForWriting(locateMapper(type, mediaType), annotations, _defaultWriteView);
         }
 
-       ;
         AnnotationBundleKey key = new AnnotationBundleKey(annotations, type);
         EP_CONFIG endpoint = _writers.get(key);
         // not yet resolved (or not cached any more)? Resolve!


### PR DESCRIPTION
* relates to https://github.com/FasterXML/jackson-jaxrs-providers/issues/166
* current synchronization does not prevent concurrent threads finding there are no cached instances and then multiple threads can create instances - once an instance is cached, then this will no longer happen
* if we want proper control so that concurrent threads can't create multiple instances, we could look at LRUMap and introduce something like Map.computeIfAbsent