### PR TITLE
Add `JaxRsFeature.READ_FULL_STREAM` to consume all content, on by default

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -458,6 +458,9 @@ public abstract class ProviderBase<
         } else {
             r = mapper.reader();
         }
+        if (JaxRSFeature.READ_FULL_STREAM.enabledIn(_jaxRSFeatures)) {
+            r = r.withFeatures(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+        }
         return _configForReading(r, annotations);
     }
 

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/JaxRSFeature.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/JaxRSFeature.java
@@ -27,6 +27,14 @@ public enum JaxRSFeature implements ConfigFeature
      */
     ALLOW_EMPTY_INPUT(true),
 
+    /**
+     * For HTTP keep-alive or multipart content to work correctly, Jackson must read the entire HTTP input
+     * stream up until reading EOF (-1).
+     * <a href="https://github.com/FasterXML/jackson-jaxrs-providers/issues/108">Issue #108</a>
+     * If set to true, always consume all input content. This has a side-effect of failing on trailing content.
+     */
+    READ_FULL_STREAM(true),
+
     /*
     /**********************************************************
     /* HTTP headers


### PR DESCRIPTION
Fixes #108