### PR TITLE
test with resteasy 4 instead of 5

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -62,7 +62,7 @@
     <dependency> 
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
-      <version>3.15.6.Final</version>
+      <version>4.7.9.Final</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -71,10 +71,10 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency> 
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.15.6.Final</version>
+      <artifactId>resteasy-core</artifactId>
+      <version>4.7.9.Final</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
* seems to be last version of resteasy to support jaxrs (as opposed to jakarta-rs)