### PR TITLE
Use `ReentrantLock`s instead of synchronized blocks

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/MapperConfiguratorBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/cfg/MapperConfiguratorBase.java
@@ -81,27 +81,27 @@ public abstract class MapperConfiguratorBase<IMPL extends MapperConfiguratorBase
     /***********************************************************
      */
 
-    public synchronized final void setMapper(MAPPER m) {
+    public final void setMapper(MAPPER m) {
         _mapper = m;
     }
 
-    public synchronized final void setAnnotationsToUse(Annotations[] annotationsToUse) {
+    public final void setAnnotationsToUse(Annotations[] annotationsToUse) {
         _setAnnotations(mapper(), annotationsToUse);
     }
 
-    public synchronized final void configure(DeserializationFeature f, boolean state) {
+    public final void configure(DeserializationFeature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(SerializationFeature f, boolean state) {
+    public final void configure(SerializationFeature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(JsonParser.Feature f, boolean state) {
+    public final void configure(JsonParser.Feature f, boolean state) {
         mapper().configure(f, state);
     }
 
-    public synchronized final void configure(JsonGenerator.Feature f, boolean state) {
+    public final void configure(JsonGenerator.Feature f, boolean state) {
         mapper().configure(f, state);
     }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMapperConfigurator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMapperConfigurator.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class CBORMapperConfigurator
     extends MapperConfiguratorBase<CBORMapperConfigurator, ObjectMapper>
 {
+    // @since 2.18
     private final ReentrantLock _lock = new ReentrantLock();
 
     /*
@@ -36,9 +37,8 @@ public class CBORMapperConfigurator
      */
     @Override
     public ObjectMapper getConfiguredMapper() {
-        /* important: should NOT call mapper(); needs to return null
-         * if no instance has been passed or constructed
-         */
+        // important: should NOT call mapper(); needs to return null
+        // if no instance has been passed or constructed
         return _mapper;
     }
 

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMapperConfigurator.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/CBORMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jaxrs.cbor;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -17,6 +18,8 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class CBORMapperConfigurator
     extends MapperConfiguratorBase<CBORMapperConfigurator, ObjectMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     /*
     /**********************************************************
     /* Construction
@@ -32,7 +35,7 @@ public class CBORMapperConfigurator
      * Method that locates, configures and returns {@link ObjectMapper} to use
      */
     @Override
-    public synchronized ObjectMapper getConfiguredMapper() {
+    public ObjectMapper getConfiguredMapper() {
         /* important: should NOT call mapper(); needs to return null
          * if no instance has been passed or constructed
          */
@@ -40,10 +43,17 @@ public class CBORMapperConfigurator
     }
 
     @Override
-    public synchronized ObjectMapper getDefaultMapper() {
+    public ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
-            _defaultMapper = new ObjectMapper(new CBORFactory());
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    _defaultMapper = new ObjectMapper(new CBORFactory());
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -63,8 +73,15 @@ public class CBORMapperConfigurator
     protected ObjectMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new ObjectMapper(new CBORFactory());
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new ObjectMapper(new CBORFactory());
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JsonMapperConfigurator.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JsonMapperConfigurator.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class JsonMapperConfigurator
     extends MapperConfiguratorBase<JsonMapperConfigurator, ObjectMapper>
 {
+    // @since 2.18
     private final ReentrantLock _lock = new ReentrantLock();
 
     /*
@@ -35,9 +36,8 @@ public class JsonMapperConfigurator
      */
     @Override
     public ObjectMapper getConfiguredMapper() {
-        /* important: should NOT call mapper(); needs to return null
-         * if no instance has been passed or constructed
-         */
+        // important: should NOT call mapper(); needs to return null
+        // if no instance has been passed or constructed
         return _mapper;
     }
 

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JsonMapperConfigurator.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JsonMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jaxrs.json;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
@@ -16,6 +17,8 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class JsonMapperConfigurator
     extends MapperConfiguratorBase<JsonMapperConfigurator, ObjectMapper>
 {
+    private final ReentrantLock _lock = new ReentrantLock();
+
     /*
     /**********************************************************
     /* Construction
@@ -31,7 +34,7 @@ public class JsonMapperConfigurator
      * Method that locates, configures and returns {@link ObjectMapper} to use
      */
     @Override
-    public synchronized ObjectMapper getConfiguredMapper() {
+    public ObjectMapper getConfiguredMapper() {
         /* important: should NOT call mapper(); needs to return null
          * if no instance has been passed or constructed
          */
@@ -39,10 +42,17 @@ public class JsonMapperConfigurator
     }
 
     @Override
-    public synchronized ObjectMapper getDefaultMapper() {
+    public ObjectMapper getDefaultMapper() {
         if (_defaultMapper == null) {
-            _defaultMapper = new ObjectMapper();
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    _defaultMapper = new ObjectMapper();
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -62,8 +72,15 @@ public class JsonMapperConfigurator
     protected ObjectMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new ObjectMapper();
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new ObjectMapper();
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -91,6 +91,8 @@ PJ Fanning (@pjfanning)
 * Contributed #166: `ProviderBase` class shows contention on synchronized
   block using `LRUMap` _writers instance
  (2.14.2)
+* Contributed #184: Use `ReentrantLock`s instead of synchronized blocks
+ (2.18.0)
 
 Steven Schlansker (@stevenschlansker)
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -12,7 +12,8 @@ Sub-modules:
 
 2.18.0 (not yet released)
 
-No changes since 2.17
+#184: Use `ReentrantLock`s instead of synchronized blocks
+ (contributed by @pjfanning)
 
 2.17.0 (12-Mar-2024)
 

--- a/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/SmileMapperConfigurator.java
+++ b/smile/src/main/java/com/fasterxml/jackson/jaxrs/smile/SmileMapperConfigurator.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class SmileMapperConfigurator
     extends MapperConfiguratorBase<SmileMapperConfigurator, ObjectMapper>
 {
+    // @since 2.18
     private final ReentrantLock _lock = new ReentrantLock();
 
     /*
@@ -37,9 +38,8 @@ public class SmileMapperConfigurator
      */
     @Override
     public ObjectMapper getConfiguredMapper() {
-        /* important: should NOT call mapper(); needs to return null
-         * if no instance has been passed or constructed
-         */
+        // important: should NOT call mapper(); needs to return null
+        // if no instance has been passed or constructed
         return _mapper;
     }
 

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/XMLMapperConfigurator.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/XMLMapperConfigurator.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class XMLMapperConfigurator
     extends MapperConfiguratorBase<XMLMapperConfigurator, XmlMapper>
 {
-
+    // @since 2.18
     private final ReentrantLock _lock = new ReentrantLock();
 
     /*
@@ -40,9 +40,8 @@ public class XMLMapperConfigurator
      */
     @Override
     public XmlMapper getConfiguredMapper() {
-        /* important: should NOT call mapper(); needs to return null
-         * if no instance has been passed or constructed
-         */
+        // important: should NOT call mapper(); needs to return null
+        // if no instance has been passed or constructed
         return _mapper;
     }
 

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/XMLMapperConfigurator.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/XMLMapperConfigurator.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.jaxrs.xml;
 
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.fasterxml.jackson.databind.*;
 
@@ -20,6 +21,9 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 public class XMLMapperConfigurator
     extends MapperConfiguratorBase<XMLMapperConfigurator, XmlMapper>
 {
+
+    private final ReentrantLock _lock = new ReentrantLock();
+
     /*
     /**********************************************************
     /* Construction
@@ -35,7 +39,7 @@ public class XMLMapperConfigurator
      * Method that locates, configures and returns {@link XmlMapper} to use
      */
     @Override
-    public synchronized XmlMapper getConfiguredMapper() {
+    public XmlMapper getConfiguredMapper() {
         /* important: should NOT call mapper(); needs to return null
          * if no instance has been passed or constructed
          */
@@ -43,13 +47,20 @@ public class XMLMapperConfigurator
     }
 
     @Override
-    public synchronized XmlMapper getDefaultMapper()
+    public XmlMapper getDefaultMapper()
     {
         if (_defaultMapper == null) {
-            // 10-Oct-2012, tatu: Better do things explicitly...
-            JacksonXmlModule module = getConfiguredModule();
-            _defaultMapper = (module == null) ? new XmlMapper() : new XmlMapper(module);
-            _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_defaultMapper == null) {
+                    // 10-Oct-2012, tatu: Better do things explicitly...
+                    JacksonXmlModule module = getConfiguredModule();
+                    _defaultMapper = (module == null) ? new XmlMapper() : new XmlMapper(module);
+                    _setAnnotations(_defaultMapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _defaultMapper;
     }
@@ -74,8 +85,15 @@ public class XMLMapperConfigurator
     protected XmlMapper mapper()
     {
         if (_mapper == null) {
-            _mapper = new XmlMapper();
-            _setAnnotations(_mapper, _defaultAnnotationsToUse);
+            _lock.lock();
+            try {
+                if (_mapper == null) {
+                    _mapper = new XmlMapper();
+                    _setAnnotations(_mapper, _defaultAnnotationsToUse);
+                }
+            } finally {
+                _lock.unlock();
+            }
         }
         return _mapper;
     }

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Annotation;
  * mapper to use can be configured in multiple ways:
  * <ul>
  * <li>By explicitly passing mapper to use in constructor
- * <li>By explcitly setting mapper to use by {@link #setMapper}
+ * <li>By explicitly setting mapper to use by {@link #setMapper}
  * <li>By defining JAX-RS <code>Provider</code> that returns {@link YAMLMapper}s.
  * <li>By doing none of above, in which case a default mapper instance is
  * constructed (and configured if configuration methods are called)

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/YAMLMapperConfigurator.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/YAMLMapperConfigurator.java
@@ -16,8 +16,9 @@ import java.util.concurrent.locks.ReentrantLock;
  * well as accessing it.
  */
 public class YAMLMapperConfigurator
-        extends MapperConfiguratorBase<YAMLMapperConfigurator, YAMLMapper> {
-
+    extends MapperConfiguratorBase<YAMLMapperConfigurator, YAMLMapper>
+{
+    // @since 2.18
     private final ReentrantLock _lock = new ReentrantLock();
 
     /*
@@ -35,9 +36,8 @@ public class YAMLMapperConfigurator
      */
     @Override
     public YAMLMapper getConfiguredMapper() {
-        /* important: should NOT call mapper(); needs to return null
-         * if no instance has been passed or constructed
-         */
+        // important: should NOT call mapper(); needs to return null
+        // if no instance has been passed or constructed
         return _mapper;
     }
 


### PR DESCRIPTION
I don't think the existing synchronized code stops multiple creations of mappers.

The new lock code double checks that the mappers are not initialized. The new locking is optimistic - we don't lock and only lock when we know we need to lazily create instances.