### PR TITLE
Add explicit `JUnit 4` dependency due to jackson-base refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,12 @@
       <version>${version.jersey}</version>
       <scope>test</scope>
     </dependency>
-
+    <!-- 20-Apr-2024 : JUnit4 no longer from jackson-base, so: -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- Alas, need to include snapshot reference since otherwise can not find


### PR DESCRIPTION
Fix https://github.com/FasterXML/jackson-bom/issues/68