### PR TITLE
Bring back code to support JAXRS v1 (revert #134 for 2.18)

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/NoContentExceptionSupplier.java
@@ -1,0 +1,13 @@
+package com.fasterxml.jackson.jaxrs.base;
+
+import java.io.IOException;
+
+/**
+ * Implementors of this class contains strategies for NoContentException creation
+ */
+public interface NoContentExceptionSupplier
+{
+  String NO_CONTENT_MESSAGE = "No content (empty input stream)";
+
+  IOException createNoContentException();
+}

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS1NoContentExceptionSupplier.java
@@ -1,0 +1,18 @@
+package com.fasterxml.jackson.jaxrs.base.nocontent;
+
+import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
+
+import java.io.IOException;
+
+/**
+ * Create plain IOException for JaxRS 1.x because {@link javax.ws.rs.core.NoContentException}
+ * has been introduced in JaxRS 2.x
+ */
+public class JaxRS1NoContentExceptionSupplier implements NoContentExceptionSupplier
+{
+  @Override
+  public IOException createNoContentException()
+  {
+    return new IOException(NO_CONTENT_MESSAGE);
+  }
+}

--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/nocontent/JaxRS2NoContentExceptionSupplier.java
@@ -1,0 +1,16 @@
+package com.fasterxml.jackson.jaxrs.base.nocontent;
+
+import com.fasterxml.jackson.jaxrs.base.NoContentExceptionSupplier;
+
+import javax.ws.rs.core.NoContentException;
+import java.io.IOException;
+
+/**
+ * This supplier creates fair NoContentException from JaxRS 2.x
+ */
+public class JaxRS2NoContentExceptionSupplier implements NoContentExceptionSupplier {
+  @Override
+  public IOException createNoContentException() {
+    return new NoContentException(NoContentExceptionSupplier.NO_CONTENT_MESSAGE);
+  }
+}

--- a/base/src/moditect/module-info.java
+++ b/base/src/moditect/module-info.java
@@ -2,6 +2,7 @@
 module com.fasterxml.jackson.jaxrs.base {
     exports com.fasterxml.jackson.jaxrs.annotation;
     exports com.fasterxml.jackson.jaxrs.base;
+    exports com.fasterxml.jackson.jaxrs.base.nocontent;
     exports com.fasterxml.jackson.jaxrs.cfg;
     exports com.fasterxml.jackson.jaxrs.util;
 

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -12,6 +12,8 @@ Sub-modules:
 
 2.18.0 (not yet released)
 
+#192: Bring back code to support JAXRS v1 (revert #134 for 2.18)
+ (contributed by @pjfanning)
 * Woodstox dependency now 7.0.0
 
 2.17.2 (05-Jul-2024)


### PR DESCRIPTION
#134 is causing real problems for Apache Hadoop and a great deal of the ecosystem of Big Data libs and tools that need to support Hadoop.

A few developers have tried to get Hadoop off of JAXRS v1 (Jersey 1) but there has been no success. 

#134 has forced Hadoop to stick to Jackson 2.12 and that version is getting increasingly stale.

https://issues.apache.org/jira/browse/HADOOP-15984 is the related Hadoop issue.