### PR TITLE
fix for not encoding json as default

### DIFF
--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonCBORProvider.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+// https://datatracker.ietf.org/doc/html/rfc8949
+@Produces({ "application/cbor", MediaType.WILDCARD })
 public class JacksonCBORProvider
 extends ProviderBase<JacksonCBORProvider,
     ObjectMapper,

--- a/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
+++ b/cbor/src/main/java/com/fasterxml/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+//https://datatracker.ietf.org/doc/html/rfc8949
+@Produces({ "application/cbor", MediaType.WILDCARD })
 public class JacksonJaxbCBORProvider extends JacksonCBORProvider {
     /**
      * Default annotation sets to use, if not explicitly defined during

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD) // NOTE: required to support "non-standard" JSON variants
-@Produces(MediaType.WILDCARD)
+@Produces({MediaType.APPLICATION_JSON, "text/json", MediaType.WILDCARD})
 public class JacksonJaxbJsonProvider extends JacksonJsonProvider {
     /**
      * Default annotation sets to use, if not explicitly defined during

--- a/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/com/fasterxml/jackson/jaxrs/json/JacksonJsonProvider.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD) // NOTE: required to support "non-standard" JSON variants
-@Produces(MediaType.WILDCARD)
+@Produces({MediaType.APPLICATION_JSON, "text/json", MediaType.WILDCARD})
 public class JacksonJsonProvider
     extends ProviderBase<JacksonJsonProvider,
         ObjectMapper,

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -100,3 +100,9 @@ Steven Schlansker (@stevenschlansker)
 
 * Contributed #170: Add `JaxRsFeature.READ_FULL_STREAM` to consume all content
  (2.15.0)
+
+Yura (@sdyura)
+
+* Contributed #193: `JacksonJaxbJsonProvider` has @Produces(MediaType.WILDCARD) and yet
+  hasMatchingMediaType(MediaType.WILDCARD) return false
+ (2.18.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,9 @@ Sub-modules:
 
 #192: Bring back code to support JAXRS v1 (revert #134 for 2.18)
  (contributed by @pjfanning)
+#193: `JacksonJaxbJsonProvider` has @Produces(MediaType.WILDCARD) and yet
+  hasMatchingMediaType(MediaType.WILDCARD) return false
+ (contributed by Yura)
 * Woodstox dependency now 7.0.0
 
 2.17.2 (05-Jul-2024)

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+@Produces({ MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.WILDCARD })
 public class JacksonJaxbXMLProvider extends JacksonXMLProvider {
     /**
      * Default annotation sets to use, if not explicitly defined during

--- a/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/com/fasterxml/jackson/jaxrs/xml/JacksonXMLProvider.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.jaxrs.cfg.Annotations;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+@Produces({ MediaType.APPLICATION_XML, MediaType.TEXT_XML, MediaType.WILDCARD })
 public class JacksonXMLProvider
     extends ProviderBase<JacksonXMLProvider,
         XmlMapper,

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
@@ -24,7 +24,8 @@ import javax.ws.rs.ext.Provider;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+// As per https://www.rfc-editor.org/rfc/rfc9512.html
+@Produces({ "application/yaml", MediaType.WILDCARD })
 public class JacksonJaxbYAMLProvider extends JacksonYAMLProvider {
     /**
      * Default annotation sets to use, if not explicitly defined during

--- a/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/com/fasterxml/jackson/jaxrs/yaml/JacksonYAMLProvider.java
@@ -52,7 +52,8 @@ import java.lang.annotation.Annotation;
  */
 @Provider
 @Consumes(MediaType.WILDCARD)
-@Produces(MediaType.WILDCARD)
+//As per https://www.rfc-editor.org/rfc/rfc9512.html
+@Produces({ "application/yaml", MediaType.WILDCARD })
 public class JacksonYAMLProvider
         extends ProviderBase<JacksonYAMLProvider,
         YAMLMapper,


### PR DESCRIPTION
fix for issue: https://github.com/FasterXML/jackson-jaxrs-providers/issues/193

copied from: https://github.com/eclipse-ee4j/jersey/blob/2.x/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingProvider.java#L53

TODO, i guess we also need a test for this