### PR TITLE
Propagate the pretty printer from the writer to the generator in `ProviderBase.writeTo()`

### DIFF
--- a/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
+++ b/base/src/main/java/com/fasterxml/jackson/jaxrs/base/ProviderBase.java
@@ -595,7 +595,12 @@ public abstract class ProviderBase<
         try {
             // Want indentation?
             if (writer.isEnabled(SerializationFeature.INDENT_OUTPUT)) {
-                g.useDefaultPrettyPrinter();
+                PrettyPrinter defaultPrettyPrinter = writer.getConfig().getDefaultPrettyPrinter();
+                if (defaultPrettyPrinter != null) {
+                    g.setPrettyPrinter(defaultPrettyPrinter);
+                } else {
+                    g.useDefaultPrettyPrinter();
+                }
             }
             JavaType rootType = null;
 

--- a/release-notes/CREDITS-2.x
+++ b/release-notes/CREDITS-2.x
@@ -106,3 +106,9 @@ Yura (@sdyura)
 * Contributed #193: `JacksonJaxbJsonProvider` has @Produces(MediaType.WILDCARD) and yet
   hasMatchingMediaType(MediaType.WILDCARD) return false
  (2.18.0)
+
+Craig P. Motlin (@motlin)
+
+* Contributed #205: Propagate the pretty printer from the writer to the generator in
+  ProviderBase.writeTo()
+ (2.19.0)

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -14,6 +14,9 @@ Sub-modules:
 
 #200: Narrow types to format specific (e.g. CBORMapper) when resolving
   via JAX-RS Providers 
+#205: Propagate the pretty printer from the writer to the generator in
+  ProviderBase.writeTo()
+ (contributed by @motlin)
 * Woodstox dependency now 7.1.0
 
 2.18.2 (27-Nov-2024)


### PR DESCRIPTION
In my Dropwizard 2.x project, I noticed that POJO responses were serialized using the pretty printer, but Response objects were not. I debugged to this section of the code and found that the pretty-printer was not propagated here.