### PR TITLE
Fix ServiceLoader manifests due to package changes

### DIFF
--- a/cbor/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
+++ b/cbor/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
@@ -1,2 +1,2 @@
-com.fasterxml.jackson.jaxrs.cbor.JacksonCBORProvider
+tools.jackson.jaxrs.cbor.JacksonCBORProvider
 

--- a/cbor/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
+++ b/cbor/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.cbor.JacksonCBORProvider
+tools.jackson.jaxrs.cbor.JacksonCBORProvider

--- a/datatypes/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.JacksonModule
+++ b/datatypes/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.JacksonModule
@@ -1,1 +1,0 @@
-com.fasterxml.jackson.datatype.jaxrs.Jaxrs2TypesModule

--- a/datatypes/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/datatypes/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,0 +1,1 @@
+tools.jackson.datatype.jaxrs.Jaxrs2TypesModule

--- a/json/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
+++ b/json/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
+tools.jackson.jaxrs.json.JacksonJsonProvider

--- a/json/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
+++ b/json/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
+tools.jackson.jaxrs.json.JacksonJsonProvider

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -1,8 +1,13 @@
 Here are people who have contributed to development Jackson JSON processor
 JAXRS-providers module, version 3.x
 (version numbers in brackets indicate release in which the problem was fixed)
-
-(note: for older credits, check out release notes for 2.x versions)
+(for Jackson 2.x credits, see CREDITS-2.x)
 
 Tatu Saloranta, tatu.saloranta@iki.fi: author
 
+----------------------------------------------------------------------------
+
+Andriy Redko (@reta)
+
+* Contributed #220: Fix ServiceLoader manifests due to 3.0 package changes
+ [3.0.1]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -11,6 +11,11 @@ Sub-modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.0.1 (not yet released)
+
+#220: Fix ServiceLoader manifests due to 3.0 package changes
+ (contributed by Andriy R)
+
 3.0.0 (03-Oct-2025)
 
 #123: Change `jackson-module-jaxb-annotations` dependency to `optional`

--- a/smile/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
+++ b/smile/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.smile.JacksonSmileProvider
+tools.jackson.jaxrs.smile.JacksonSmileProvider

--- a/smile/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
+++ b/smile/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.smile.JacksonSmileProvider
+tools.jackson.jaxrs.smile.JacksonSmileProvider

--- a/xml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
+++ b/xml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
@@ -1,2 +1,2 @@
-com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider
+tools.jackson.jaxrs.xml.JacksonXMLProvider
 

--- a/xml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
+++ b/xml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider
+tools.jackson.jaxrs.xml.JacksonXMLProvider

--- a/yaml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
+++ b/yaml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyReader
@@ -1,2 +1,2 @@
-com.fasterxml.jackson.jaxrs.yaml.JacksonYAMLProvider
+tools.jackson.jaxrs.yaml.JacksonYAMLProvider
 

--- a/yaml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
+++ b/yaml/src/main/resources/META-INF/services/javax.ws.rs.ext.MessageBodyWriter
@@ -1,1 +1,1 @@
-com.fasterxml.jackson.jaxrs.yaml.JacksonYAMLProvider
+tools.jackson.jaxrs.yaml.JacksonYAMLProvider


### PR DESCRIPTION
Similarly to https://github.com/FasterXML/jackson-jakarta-rs-providers/pull/57, fixing  `ServiceLoader` manifests due to package changes