### PR TITLE
Create SPI metadata verification (unit) test

### DIFF
--- a/cbor/src/test/java/module-info.java
+++ b/cbor/src/test/java/module-info.java
@@ -21,4 +21,9 @@ module tools.jackson.jaxrs.cbor
     opens tools.jackson.jaxrs.cbor;
     opens tools.jackson.jaxrs.cbor.dw;
     opens tools.jackson.jaxrs.cbor.jersey;
+
+    // ServiceLoader tests
+    uses javax.ws.rs.ext.MessageBodyWriter;
+    uses javax.ws.rs.ext.MessageBodyReader;
+
 }

--- a/cbor/src/test/java/tools/jackson/jaxrs/cbor/ServiceLoaderIT.java
+++ b/cbor/src/test/java/tools/jackson/jaxrs/cbor/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jaxrs.cbor;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.cbor.JacksonCBORProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.cbor.JacksonCBORProvider.class
+            ));
+    }
+}

--- a/datatypes/src/test/java/module-info.java
+++ b/datatypes/src/test/java/module-info.java
@@ -14,4 +14,7 @@ module tools.jackson.datatype.jaxrs
     // Further, need to open up test packages for JUnit et al
     
     opens tools.jackson.datatype.jaxrs;
+
+    // ServiceLoader tests
+    uses tools.jackson.databind.JacksonModule;
 }

--- a/datatypes/src/test/java/tools/jackson/datatype/jaxrs/ServiceLoaderIT.java
+++ b/datatypes/src/test/java/tools/jackson/datatype/jaxrs/ServiceLoaderIT.java
@@ -1,0 +1,30 @@
+package tools.jackson.datatype.jaxrs;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JacksonModule;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testJacksonModule() {
+        final List<JacksonModule> providers = ServiceLoader
+            .load(JacksonModule.class)
+            .stream()
+            .map(Provider<JacksonModule>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.datatype.jaxrs.Jaxrs2TypesModule.class
+            ));
+    }
+}

--- a/json/src/test/java/module-info.java
+++ b/json/src/test/java/module-info.java
@@ -22,4 +22,8 @@ module tools.jackson.jaxrs.json
     opens tools.jackson.jaxrs.json.jersey;
     opens tools.jackson.jaxrs.json.testutil;
     opens tools.jackson.jaxrs.json.util;
+
+    // ServiceLoader tests
+    uses javax.ws.rs.ext.MessageBodyWriter;
+    uses javax.ws.rs.ext.MessageBodyReader;
 }

--- a/json/src/test/java/tools/jackson/jaxrs/json/ServiceLoaderIT.java
+++ b/json/src/test/java/tools/jackson/jaxrs/json/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jaxrs.json;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.json.JacksonJsonProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.json.JacksonJsonProvider.class
+            ));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,25 @@ https://stackoverflow.com/questions/44088493/jersey-stopped-working-with-injecti
   </repositories>
   
   <build>
+    <plugins>
+      <!-- ServiceLoader tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.5.4</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@ https://stackoverflow.com/questions/44088493/jersey-stopped-working-with-injecti
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.4</version>
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>

--- a/smile/src/test/java/module-info.java
+++ b/smile/src/test/java/module-info.java
@@ -21,4 +21,8 @@ module tools.jackson.jaxrs.smile
     opens tools.jackson.jaxrs.smile;
     opens tools.jackson.jaxrs.smile.dw;
     opens tools.jackson.jaxrs.smile.jersey;
+
+    // ServiceLoader tests
+    uses javax.ws.rs.ext.MessageBodyWriter;
+    uses javax.ws.rs.ext.MessageBodyReader;
 }

--- a/smile/src/test/java/tools/jackson/jaxrs/smile/ServiceLoaderIT.java
+++ b/smile/src/test/java/tools/jackson/jaxrs/smile/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jaxrs.smile;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.smile.JacksonSmileProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.smile.JacksonSmileProvider.class
+            ));
+    }
+}

--- a/xml/src/test/java/module-info.java
+++ b/xml/src/test/java/module-info.java
@@ -21,4 +21,8 @@ module tools.jackson.jaxrs.xml
     opens tools.jackson.jaxrs.xml;
     opens tools.jackson.jaxrs.xml.dw;
     opens tools.jackson.jaxrs.xml.jersey;
+
+    // ServiceLoader tests
+    uses javax.ws.rs.ext.MessageBodyWriter;
+    uses javax.ws.rs.ext.MessageBodyReader;
 }

--- a/xml/src/test/java/tools/jackson/jaxrs/xml/ServiceLoaderIT.java
+++ b/xml/src/test/java/tools/jackson/jaxrs/xml/ServiceLoaderIT.java
@@ -1,0 +1,49 @@
+package tools.jackson.jaxrs.xml;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.xml.JacksonXMLProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.xml.JacksonXMLProvider.class
+            ));
+    }
+}

--- a/yaml/src/test/java/module-info.java
+++ b/yaml/src/test/java/module-info.java
@@ -27,4 +27,8 @@ module tools.jackson.jaxrs.yaml
     opens tools.jackson.jaxrs.yaml;
     opens tools.jackson.jaxrs.yaml.dw;
     opens tools.jackson.jaxrs.yaml.jersey;
+
+    // ServiceLoader tests
+    uses javax.ws.rs.ext.MessageBodyWriter;
+    uses javax.ws.rs.ext.MessageBodyReader;
 }

--- a/yaml/src/test/java/tools/jackson/jaxrs/yaml/ServiceLoaderIT.java
+++ b/yaml/src/test/java/tools/jackson/jaxrs/yaml/ServiceLoaderIT.java
@@ -1,0 +1,53 @@
+package tools.jackson.jaxrs.yaml;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceLoaderIT {
+    @Test
+    public void testMessageBodyWriter() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyWriter> providers = ServiceLoader
+            .load(MessageBodyWriter.class)
+            .stream()
+            .map(Provider<MessageBodyWriter>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.json.JacksonJsonProvider.class, 
+                tools.jackson.jaxrs.smile.JacksonSmileProvider.class,
+                tools.jackson.jaxrs.yaml.JacksonYAMLProvider.class
+            ));
+    }
+
+    @Test
+    public void testMessageBodyReader() {
+        @SuppressWarnings("rawtypes")
+        final List<MessageBodyReader> providers = ServiceLoader
+            .load(MessageBodyReader.class)
+            .stream()
+            .map(Provider<MessageBodyReader>::get)
+            .toList();
+
+        assertEquals(providers
+            .stream()
+            .map(w -> w.getClass())
+            .sorted(Comparator.comparing(Class::getSimpleName)).toList(), List.of(
+                tools.jackson.jaxrs.json.JacksonJsonProvider.class, 
+                tools.jackson.jaxrs.smile.JacksonSmileProvider.class,
+                tools.jackson.jaxrs.yaml.JacksonYAMLProvider.class
+            ));
+    }
+}


### PR DESCRIPTION
To verify against regression wrt https://github.com/FasterXML/jackson-jakarta-rs-providers/pull/57, it'd be great to have simple unit test(s) to instantiate providers using `ServiceLoader`. That should at least have caught specific problem of wrong Java package name for format backends.

Part of https://github.com/FasterXML/jackson-jakarta-rs-providers/issues/58