### PR TITLE
Issue 226: MapperConfigurator-Ctors for Providers

### DIFF
--- a/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonCBORProvider.java
@@ -102,6 +102,14 @@ extends ProviderBase<JacksonCBORProvider,
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonCBORProvider(CBORMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonCBORProvider.java
@@ -104,6 +104,7 @@ extends ProviderBase<JacksonCBORProvider,
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonCBORProvider(CBORMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
@@ -51,6 +51,14 @@ public class JacksonJaxbCBORProvider extends JacksonCBORProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonJaxbCBORProvider(CBORMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
+++ b/cbor/src/main/java/tools/jackson/jaxrs/cbor/JacksonJaxbCBORProvider.java
@@ -54,6 +54,7 @@ public class JacksonJaxbCBORProvider extends JacksonCBORProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonJaxbCBORProvider(CBORMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
@@ -48,6 +48,14 @@ public class JacksonJaxbJsonProvider extends JacksonJsonProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonJaxbJsonProvider(JsonMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/json/src/main/java/tools/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jaxrs/json/JacksonJaxbJsonProvider.java
@@ -51,6 +51,7 @@ public class JacksonJaxbJsonProvider extends JacksonJsonProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonJaxbJsonProvider(JsonMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jaxrs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jaxrs/json/JacksonJsonProvider.java
@@ -118,6 +118,8 @@ public class JacksonJsonProvider
      * some methods from MapperConfiguratorBase)
      *
      * @param mapperConfigurator custom mapper configurator to use
+     * 
+     * @since 3.1
      */
     public JacksonJsonProvider(JsonMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/json/src/main/java/tools/jackson/jaxrs/json/JacksonJsonProvider.java
+++ b/json/src/main/java/tools/jackson/jaxrs/json/JacksonJsonProvider.java
@@ -114,6 +114,16 @@ public class JacksonJsonProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     *
+     * @param mapperConfigurator custom mapper configurator to use
+     */
+    public JacksonJsonProvider(JsonMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -11,3 +11,8 @@ Andriy Redko (@reta)
 
 * Contributed #220: Fix ServiceLoader manifests due to 3.0 package changes
  [3.0.1]
+
+Jens-Otto Larsen (@jolarsen)
+
+* Contributed #226: Add constructor accepting `JsonMapperConfigurator` to `Jackson(Jaxb)JsonProvider`
+ [3.1.0]

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -11,6 +11,11 @@ Sub-modules:
 === Releases ===
 ------------------------------------------------------------------------
 
+3.1.0 (not yet released)
+
+#226: Add constructor accepting `JsonMapperConfigurator` to `Jackson(Jaxb)JsonProvider`
+ (contributed by Jens-Otto L)
+
 3.0.3 (28-Nov-2025)
 3.0.2 (07-Nov-2025)
 

--- a/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
@@ -47,6 +47,14 @@ public class JacksonJaxbSmileProvider extends JacksonSmileProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonJaxbSmileProvider(SmileMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonJaxbSmileProvider.java
@@ -50,6 +50,7 @@ public class JacksonJaxbSmileProvider extends JacksonSmileProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonJaxbSmileProvider(SmileMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonSmileProvider.java
@@ -103,6 +103,7 @@ extends ProviderBase<JacksonSmileProvider,
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonSmileProvider(SmileMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonSmileProvider.java
+++ b/smile/src/main/java/tools/jackson/jaxrs/smile/JacksonSmileProvider.java
@@ -101,6 +101,14 @@ extends ProviderBase<JacksonSmileProvider,
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonSmileProvider(SmileMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
@@ -48,6 +48,14 @@ public class JacksonJaxbXMLProvider extends JacksonXMLProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonJaxbXMLProvider(XMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonJaxbXMLProvider.java
@@ -51,6 +51,7 @@ public class JacksonJaxbXMLProvider extends JacksonXMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonJaxbXMLProvider(XMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonXMLProvider.java
@@ -97,6 +97,14 @@ public class JacksonXMLProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonXMLProvider(XMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonXMLProvider.java
+++ b/xml/src/main/java/tools/jackson/jaxrs/xml/JacksonXMLProvider.java
@@ -99,6 +99,7 @@ public class JacksonXMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonXMLProvider(XMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
@@ -47,6 +47,14 @@ public class JacksonJaxbYAMLProvider extends JacksonYAMLProvider
         super(mapper, aiOverride);
     }
 
+    /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonJaxbYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
     // Silly class to encapsulate reference to JAXB introspector class so that
     // loading of parent class does not require it; only happens if and when
     // introspector needed

--- a/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonJaxbYAMLProvider.java
@@ -50,6 +50,7 @@ public class JacksonJaxbYAMLProvider extends JacksonYAMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonJaxbYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);

--- a/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonYAMLProvider.java
@@ -108,6 +108,14 @@ public class JacksonYAMLProvider
     }
 
     /**
+     * Constructor for use with a custom mapperConfigurator (usually implementing
+     * some methods from MapperConfiguratorBase)
+     */
+    public JacksonYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
+        super(mapperConfigurator);
+    }
+
+    /**
      * Method that will return version information stored in and read from jar
      * that contains this class.
      */

--- a/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonYAMLProvider.java
+++ b/yaml/src/main/java/tools/jackson/jaxrs/yaml/JacksonYAMLProvider.java
@@ -110,6 +110,7 @@ public class JacksonYAMLProvider
     /**
      * Constructor for use with a custom mapperConfigurator (usually implementing
      * some methods from MapperConfiguratorBase)
+     * @since 3.1
      */
     public JacksonYAMLProvider(YAMLMapperConfigurator mapperConfigurator) {
         super(mapperConfigurator);


### PR DESCRIPTION
Extra constructor for Provider-classes to facilitate customizing MapperConfigurators - for instance implementing mapperBuilder() or _builderWithConfiguration() when no mapper is supplied (null). 
This offers better support for immutable mappers and is preferrable to hacking _locateMapperViaProvider